### PR TITLE
Various improvements

### DIFF
--- a/src/hexdump.c
+++ b/src/hexdump.c
@@ -1,3 +1,5 @@
+#include<ctype.h>
+#include<stdbool.h>
 #include<stdio.h>
 #include<stdint.h>
 #include<sys/stat.h>
@@ -6,11 +8,22 @@
 #define LINE_COUNTER_WIDTH   8
 #define BYTES_PER_LINE       16
 
-#define PRINTABLE_MIN_ASCII  32
-#define PRINTABLE_MAX_ASCII  126    // https://en.wikipedia.org/wiki/ASCII#Printable_characters
-
 #define PRINTF_BUFFER_SIZE   3200
 
+/* Prints out the ASCII-view sidebar in canonical mode
+ * e.g. |hello..| for 'h','e','l','l','o','\r','\n'.
+ * Does not include a trailing newline. */
+void print_sidebar(FILE *output_stream, char *line, int line_len)
+{
+    int i;
+
+    fputc('|', output_stream);
+    for(i = 0; i < line_len; ++i){
+        fputc(isprint(line[i]) ? line[i] : '.', output_stream);
+    }
+    fputc('|', output_stream);
+}
+    
 int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,char *output_file_name)
 {
     FILE *input_stream;
@@ -89,7 +102,7 @@ int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,cha
 
     if(byte_cursor % BYTES_PER_LINE != 0)
     {
-        int stop_execution = FALSE;
+        int stop_execution = false;
 
         for(uint64_t i = 0; i < BYTES_PER_LINE; i++)
         {
@@ -103,39 +116,27 @@ int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,cha
 
             if(line[i] == EOF || no_of_bytes == 0)
             {
-                stop_execution = TRUE;
+                stop_execution = true;
                 break;
             }       
         }
 
         fprintf(output_stream,
-                "%.*llx  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  |%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c|\n",
+                "%.*llx  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  ",
                 LINE_COUNTER_WIDTH, line_count,
                 line[0],line[1],line[2],line[3],line[4],line[5],line[6],line[7],
-                line[8],line[9],line[10],line[11],line[12],line[13],line[14],line[15],
-                (line[ 0] >= PRINTABLE_MIN_ASCII && line[ 0] <= PRINTABLE_MAX_ASCII) ? line[ 0] : '.',
-                (line[ 1] >= PRINTABLE_MIN_ASCII && line[ 1] <= PRINTABLE_MAX_ASCII) ? line[ 1] : '.',
-                (line[ 2] >= PRINTABLE_MIN_ASCII && line[ 2] <= PRINTABLE_MAX_ASCII) ? line[ 2] : '.',
-                (line[ 3] >= PRINTABLE_MIN_ASCII && line[ 3] <= PRINTABLE_MAX_ASCII) ? line[ 3] : '.',
-                (line[ 4] >= PRINTABLE_MIN_ASCII && line[ 4] <= PRINTABLE_MAX_ASCII) ? line[ 4] : '.',
-                (line[ 5] >= PRINTABLE_MIN_ASCII && line[ 5] <= PRINTABLE_MAX_ASCII) ? line[ 5] : '.',
-                (line[ 6] >= PRINTABLE_MIN_ASCII && line[ 6] <= PRINTABLE_MAX_ASCII) ? line[ 6] : '.',
-                (line[ 7] >= PRINTABLE_MIN_ASCII && line[ 7] <= PRINTABLE_MAX_ASCII) ? line[ 7] : '.',
-                (line[ 8] >= PRINTABLE_MIN_ASCII && line[ 8] <= PRINTABLE_MAX_ASCII) ? line[ 8] : '.',
-                (line[ 9] >= PRINTABLE_MIN_ASCII && line[ 9] <= PRINTABLE_MAX_ASCII) ? line[ 9] : '.',
-                (line[10] >= PRINTABLE_MIN_ASCII && line[10] <= PRINTABLE_MAX_ASCII) ? line[10] : '.',
-                (line[11] >= PRINTABLE_MIN_ASCII && line[11] <= PRINTABLE_MAX_ASCII) ? line[11] : '.',
-                (line[12] >= PRINTABLE_MIN_ASCII && line[12] <= PRINTABLE_MAX_ASCII) ? line[12] : '.',
-                (line[13] >= PRINTABLE_MIN_ASCII && line[13] <= PRINTABLE_MAX_ASCII) ? line[13] : '.',
-                (line[14] >= PRINTABLE_MIN_ASCII && line[14] <= PRINTABLE_MAX_ASCII) ? line[14] : '.',
-                (line[15] >= PRINTABLE_MIN_ASCII && line[15] <= PRINTABLE_MAX_ASCII) ? line[15] : '.'
-                );   
-                line_count++;
+                line[8],line[9],line[10],line[11],line[12],line[13],line[14],line[15]
+               	);
 
-                if(stop_execution)
-                {
-                    return 0;
-                }
+        print_sidebar(output_stream, line, 16);
+        fputc('\n', output_stream);
+
+        line_count++;
+
+        if(stop_execution)
+        {
+            return 0;
+        }
     }
 
     while( (int_byte = fgetc(input_stream)) != EOF && no_of_bytes != 0)
@@ -143,34 +144,20 @@ int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,cha
         if( line_cursor == BYTES_PER_LINE )
         {
             fprintf(output_stream,
-                "%.*llx  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  |%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c|\n",
+                "%.*llx  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  ",
                 LINE_COUNTER_WIDTH, line_count,
                 line[0],line[1],line[2],line[3],line[4],line[5],line[6],line[7],
-                line[8],line[9],line[10],line[11],line[12],line[13],line[14],line[15],
-                (line[ 0] >= PRINTABLE_MIN_ASCII && line[ 0] <= PRINTABLE_MAX_ASCII) ? line[ 0] : '.',
-                (line[ 1] >= PRINTABLE_MIN_ASCII && line[ 1] <= PRINTABLE_MAX_ASCII) ? line[ 1] : '.',
-                (line[ 2] >= PRINTABLE_MIN_ASCII && line[ 2] <= PRINTABLE_MAX_ASCII) ? line[ 2] : '.',
-                (line[ 3] >= PRINTABLE_MIN_ASCII && line[ 3] <= PRINTABLE_MAX_ASCII) ? line[ 3] : '.',
-                (line[ 4] >= PRINTABLE_MIN_ASCII && line[ 4] <= PRINTABLE_MAX_ASCII) ? line[ 4] : '.',
-                (line[ 5] >= PRINTABLE_MIN_ASCII && line[ 5] <= PRINTABLE_MAX_ASCII) ? line[ 5] : '.',
-                (line[ 6] >= PRINTABLE_MIN_ASCII && line[ 6] <= PRINTABLE_MAX_ASCII) ? line[ 6] : '.',
-                (line[ 7] >= PRINTABLE_MIN_ASCII && line[ 7] <= PRINTABLE_MAX_ASCII) ? line[ 7] : '.',
-                (line[ 8] >= PRINTABLE_MIN_ASCII && line[ 8] <= PRINTABLE_MAX_ASCII) ? line[ 8] : '.',
-                (line[ 9] >= PRINTABLE_MIN_ASCII && line[ 9] <= PRINTABLE_MAX_ASCII) ? line[ 9] : '.',
-                (line[10] >= PRINTABLE_MIN_ASCII && line[10] <= PRINTABLE_MAX_ASCII) ? line[10] : '.',
-                (line[11] >= PRINTABLE_MIN_ASCII && line[11] <= PRINTABLE_MAX_ASCII) ? line[11] : '.',
-                (line[12] >= PRINTABLE_MIN_ASCII && line[12] <= PRINTABLE_MAX_ASCII) ? line[12] : '.',
-                (line[13] >= PRINTABLE_MIN_ASCII && line[13] <= PRINTABLE_MAX_ASCII) ? line[13] : '.',
-                (line[14] >= PRINTABLE_MIN_ASCII && line[14] <= PRINTABLE_MAX_ASCII) ? line[14] : '.',
-                (line[15] >= PRINTABLE_MIN_ASCII && line[15] <= PRINTABLE_MAX_ASCII) ? line[15] : '.'
+                line[8],line[9],line[10],line[11],line[12],line[13],line[14],line[15]
                 );
+            print_sidebar(output_stream, line, 16);
+            fputc('\n', output_stream);
 
-                line_count  += 16;
-                line_cursor  =  0;
+            line_count  += 16;
+            line_cursor  =  0;
 
-                line[line_cursor] = int_byte;
-                no_of_bytes--;
-                line_cursor++;
+            line[line_cursor] = int_byte;
+            no_of_bytes--;
+            line_cursor++;
         }
         else
         {
@@ -188,26 +175,12 @@ int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,cha
         line[i] = 0;
     }
     fprintf(output_stream,
-        "%.*llx  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  |%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c|\n",
+        "%.*llx  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  %.2x %.2x %.2x %.2x %.2x %.2x %.2x %.2x  ",
         LINE_COUNTER_WIDTH, line_count,
         line[0], line[1], line[2], line[3], line[4], line[5], line[6], line[7],
-        line[8], line[9], line[10], line[11], line[12], line[13], line[14], line[15],
-        (line[ 0] >= PRINTABLE_MIN_ASCII && line[ 0] <= PRINTABLE_MAX_ASCII) ? line[ 0] : '.',
-        (line[ 1] >= PRINTABLE_MIN_ASCII && line[ 1] <= PRINTABLE_MAX_ASCII) ? line[ 1] : '.',
-        (line[ 2] >= PRINTABLE_MIN_ASCII && line[ 2] <= PRINTABLE_MAX_ASCII) ? line[ 2] : '.',
-        (line[ 3] >= PRINTABLE_MIN_ASCII && line[ 3] <= PRINTABLE_MAX_ASCII) ? line[ 3] : '.',
-        (line[ 4] >= PRINTABLE_MIN_ASCII && line[ 4] <= PRINTABLE_MAX_ASCII) ? line[ 4] : '.',
-        (line[ 5] >= PRINTABLE_MIN_ASCII && line[ 5] <= PRINTABLE_MAX_ASCII) ? line[ 5] : '.',
-        (line[ 6] >= PRINTABLE_MIN_ASCII && line[ 6] <= PRINTABLE_MAX_ASCII) ? line[ 6] : '.',
-        (line[ 7] >= PRINTABLE_MIN_ASCII && line[ 7] <= PRINTABLE_MAX_ASCII) ? line[ 7] : '.',
-        (line[ 8] >= PRINTABLE_MIN_ASCII && line[ 8] <= PRINTABLE_MAX_ASCII) ? line[ 8] : '.',
-        (line[ 9] >= PRINTABLE_MIN_ASCII && line[ 9] <= PRINTABLE_MAX_ASCII) ? line[ 9] : '.',
-        (line[10] >= PRINTABLE_MIN_ASCII && line[10] <= PRINTABLE_MAX_ASCII) ? line[10] : '.',
-        (line[11] >= PRINTABLE_MIN_ASCII && line[11] <= PRINTABLE_MAX_ASCII) ? line[11] : '.',
-        (line[12] >= PRINTABLE_MIN_ASCII && line[12] <= PRINTABLE_MAX_ASCII) ? line[12] : '.',
-        (line[13] >= PRINTABLE_MIN_ASCII && line[13] <= PRINTABLE_MAX_ASCII) ? line[13] : '.',
-        (line[14] >= PRINTABLE_MIN_ASCII && line[14] <= PRINTABLE_MAX_ASCII) ? line[14] : '.',
-        (line[15] >= PRINTABLE_MIN_ASCII && line[15] <= PRINTABLE_MAX_ASCII) ? line[15] : '.');
+        line[8], line[9], line[10], line[11], line[12], line[13], line[14], line[15]);
+    print_sidebar(output_stream, line, 16);
+    fputc('\n', output_stream);
 
     fclose(input_stream);
     fclose(output_stream);

--- a/src/hexdump.c
+++ b/src/hexdump.c
@@ -1,5 +1,4 @@
 #include<ctype.h>
-#include<stdbool.h>
 #include<stdio.h>
 #include<stdint.h>
 #include<sys/stat.h>

--- a/src/hexdump.h
+++ b/src/hexdump.h
@@ -3,6 +3,14 @@
 
 #define HEXDUMP_VERSION "0.1.0"
 
+/* Poor man's <stdbool.h> for pre-C99 standard libraries. */
+#ifndef __bool_true_false_are_defined
+#define false 0
+#define true 1
+#define bool _Bool
+typedef _Bool unsigned char;
+#endif
+
 int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,char *output_file_name);
 
 #endif

--- a/src/hexdump.h
+++ b/src/hexdump.h
@@ -3,12 +3,10 @@
 
 #define HEXDUMP_VERSION "0.1.0"
 
-/* Poor man's <stdbool.h> for pre-C99 standard libraries. */
+/* Poor man's partial <stdbool.h> for pre-C99 standard libraries. */
 #ifndef __bool_true_false_are_defined
 #define false 0
 #define true 1
-#define bool _Bool
-typedef _Bool unsigned char;
 #endif
 
 int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,char *output_file_name);

--- a/src/hexdump.h
+++ b/src/hexdump.h
@@ -3,9 +3,6 @@
 
 #define HEXDUMP_VERSION "0.1.0"
 
-#define FALSE 0
-#define TRUE  1
-
 int print_hex(char *input_file_name,uint64_t start_byte,uint64_t no_of_bytes,char *output_file_name);
 
 #endif


### PR DESCRIPTION
## style
I tried to use the style you're already using. I unindented some lines that your editor probably auto-indented because of the preceding fprintfs.

## ctype.h
isprint(3) provides the `c >= ' ' && c <= '~'` functionality you were expecting.

## print_sidebar
This does away with a lot of repeated code.

## stdbool.h
This is a C99 thing but you're already using some C99 additions (I see variable declarations in `for` statements) so I don't think this is a problem.

These are some improvements. Consider doing away with hard-coded line[0],line[1]...s and use a `for` loop that checks for `i < BYTES_PER_LINE` when printing the bytes. I also see some type warnings with fprintf(3) formatting that could be fixed. All in all, pretty cool hexdump(1) implementation!